### PR TITLE
add separateMinorPatch to automerge patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     "semanticCommitType": "chore",
     "packageRules": [
       {
+        "separateMinorPatch": true,
         "depTypeList": [
           "devDependencies"
         ],


### PR DESCRIPTION
`separateMinorPatch` seems to be required to enable automerge.

> Configuration to apply when an update type is patch. Only applies if separateMinorPatch is set to true

https://docs.renovatebot.com/configuration-options/#patch