### PR TITLE
:sparkles: add a renovate label for a PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
     ":timezone(Asia/Tokyo)",
     "group:monorepos",
     "packages:stylelint",
-    ":widenPeerDependencies"
+    ":widenPeerDependencies",
+    ":label(renovate)"
   ],
   "npm": {
     "extends": [


### PR DESCRIPTION
This PR adds a "renovate" label for all PRs from Renovate.
If you'd like to add another name for the label, you can change like `:label(whatyouwant)`.

docs: https://docs.renovatebot.com/presets-default/#labelltarg0gt