### PR TITLE
fix: separateMinorPatch should be placed outside pacakgeRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,9 +15,9 @@
     "schedule": "before 10am on Monday",
     "rangeStrategy": "bump",
     "semanticCommitType": "chore",
+    "separateMinorPatch": true,
     "packageRules": [
       {
-        "separateMinorPatch": true,
         "depTypeList": [
           "devDependencies"
         ],


### PR DESCRIPTION
Currently, this config cannot enable an auto-merge setting for patch versions because it doesn't split `minor` and `patch` version.
https://github.com/renovatebot/config-help/issues/661#issuecomment-630207573

This seems to be caused by not putting `separateMinorPatch: true` in the appropriate place, so I've fixed this.

This PR would change the behavior of Renovate.
If a package's version is `1.0.0`, and has new versions `1.0.1` and `1.1.0`, Renovate would create 2PRs for `1.0.1`(auto-merge) and `1.1.0`(not auto-merge). 