### PR TITLE
prevent updating styled-components v5.2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,6 +46,10 @@
         "packagePatterns": [
           "^reg-"
         ]
+      },
+      {
+        "packageNames": ["styled-components"],
+        "allowedVersions": [">5.2.0"]
       }
     ]
   }


### PR DESCRIPTION
## motivation
styled-components v5.2 includes IE11 white-out bug (https://github.com/styled-components/styled-components/issues/3266), so we MUST NOT use this version.

## changes

- set `allowedVersions` of styled-components higher than `5.2`