### PR TITLE
prevent updating styled-components v5.2

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
       },
       {
         "packageNames": ["styled-components"],
-        "allowedVersions": [">5.2.0"]
+        "allowedVersions": "!/5\\.2\\.0$/"
       }
     ]
   }


### PR DESCRIPTION
## motivation
- styled-components v5.2 includes IE11 white-out bug ([styled-components/styled-components#3266](https://github.com/styled-components/styled-components/issues/3266)), so we MUST NOT use this version.


## changes
- fix #4 invalid settings error
    - I want to avoid only `v5.2.0` so use negated regular expression ([doc](https://docs.renovatebot.com/configuration-options/#allowedversions))
- run `npx --package renovate -c 'renovate-config-validator'` and validate settings ([Qiita](https://qiita.com/noriaki/items/5cba282902d79e539d8a))