### PR TITLE
prevent updating React-Pdf to v5.0.0

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,10 @@
       {
         "packageNames": ["styled-components"],
         "allowedVersions": "!/5\\.2\\.0$/"
+      },
+      {
+        "packageNames": ["react-pdf"],
+        "allowedVersions": "<5.0.0"
       }
     ]
   }


### PR DESCRIPTION
[React-PDF v5.0.0 doesn't support IE11.](https://github.com/wojtekmaj/react-pdf/releases/tag/v5.0.0)