### PR TITLE
remove config for styled-components

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,10 +48,6 @@
         ]
       },
       {
-        "packageNames": ["styled-components"],
-        "allowedVersions": "!/5\\.2\\.0$/"
-      },
-      {
         "packageNames": ["react-pdf"],
         "allowedVersions": "<5.0.0"
       }


### PR DESCRIPTION
## motivation

styled-components v5.2.0 has IE bug, but as of v5.2.1, it's been fixed.
So, the config for styled-components is no longer needed.

## changes

Deleted the config for styled-components.