### PR TITLE
chore: prevent updating husky to v5

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,10 @@
       {
         "packageNames": ["query-string"],
         "allowedVersions": "<6.0.0"
+      },
+      {
+        "packageNames": ["husky"],
+        "allowedVersions": "<5.0.0"
       }
     ]
   }


### PR DESCRIPTION
[If you're using husky in a commercial project, you may want to consider becoming a sponsor to support the project. You can also try it for 30 days.](https://github.com/typicode/husky/releases/tag/v5.0.0)

> This is only for a limited time, husky will be MIT again later.

I might be able to unlock this someday...