### PR TITLE
chore: fix html-to-image to v0.1.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -58,6 +58,10 @@
       {
         "packageNames": ["husky"],
         "allowedVersions": "<5.0.0"
+      },
+      {
+        "packageNames": ["html-to-image"],
+        "allowedVersions": "<=0.1.1"
       }
     ]
   }


### PR DESCRIPTION
fix `html-to-image` version to 0.1.1
ref: https://github.com/kufu/meyasu/pull/936