### PR TITLE
remove allowedVersions of husky

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",
-      ":unpublishSafe",
+      "npm:unpublishSafe",
       "helpers:disableTypesNodeMajor"
     ],
     "schedule": "before 10am on Monday",
@@ -18,41 +18,41 @@
     "separateMinorPatch": true,
     "packageRules": [
       {
-        "depTypeList": [
+        "matchDepTypes": [
           "devDependencies"
         ],
-        "updateTypes": [
+        "matchUpdateTypes": [
           "patch"
         ],
         "automerge": true
       },
       {
         "groupName": "ESLint and Prettier",
-        "packageNames": [
+        "matchPackageNames": [
           "eslint",
           "prettier"
         ],
-        "packagePatterns": [
+        "matchPackagePatterns": [
           "^eslint-",
           "^prettier-"
         ]
       },
       {
         "groupName": "reg-suit",
-        "packageNames": [
+        "matchPackageNames": [
           "reg-suit",
           "storycap"
         ],
-        "packagePatterns": [
+        "matchPackagePatterns": [
           "^reg-"
         ]
       },
       {
-        "packageNames": ["react-pdf"],
+        "matchPackageNames": ["react-pdf"],
         "allowedVersions": "<5.0.0"
       },
       {
-        "packageNames": ["query-string"],
+        "matchPackageNames": ["query-string"],
         "allowedVersions": "<6.0.0"
       }
     ]

--- a/renovate.json
+++ b/renovate.json
@@ -54,10 +54,6 @@
       {
         "packageNames": ["query-string"],
         "allowedVersions": "<6.0.0"
-      },
-      {
-        "packageNames": ["husky"],
-        "allowedVersions": "<5.0.0"
       }
     ]
   }


### PR DESCRIPTION
## motivation

husky's license is back to MIT so want to remove `allowedVersion` of husky.

## what we did

* remove `allowedVersion` of husky
    * c35c82d
* migrate config to newConfig
    * a12f4a1
* resolve conflict
    * 32813eb

## how to check

* clone this PR
* run `npx --package renovate -c 'renovate-config-validator'`
* ✅ 