### PR TITLE
fix: add ":semanticCommitScopeDisabled"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "group:monorepos",
     "packages:stylelint",
     ":widenPeerDependencies",
-    ":label(renovate)"
+    ":label(renovate)",
+    ":semanticCommitScopeDisabled"
   ],
   "npm": {
     "extends": [


### PR DESCRIPTION
## What I did

added `":semanticCommitScopeDisabled"` to `extends`

## Why I did

the prefix for pull requests needs to be `chore:` (instead of`chore:(deps)`) when to use [Title Lint](https://github.com/apps/title-lint)
see: https://docs.renovatebot.com/semantic-commits/