### PR TITLE
chore: move `schedule` to the top level

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,11 +57,11 @@
         "allowedVersions": "<6.0.0"
       },
       {
-        "packageNames": ["html-to-image"],
+        "matchPackageNames": ["html-to-image"],
         "allowedVersions": "<=0.1.1"
       },
       {
-        "packageNames": ["i18n-iso-countries"],
+        "matchPackageNames": ["i18n-iso-countries"],
         "allowedVersions": "<6.0.0"
       }
     ]

--- a/renovate.json
+++ b/renovate.json
@@ -7,13 +7,13 @@
     ":label(renovate)",
     ":semanticCommitScopeDisabled"
   ],
+  "schedule": "after 8am before 10am on Monday",
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",
       "npm:unpublishSafe",
       "helpers:disableTypesNodeMajor"
     ],
-    "schedule": "before 10am on Monday",
     "rangeStrategy": "bump",
     "semanticCommitType": "chore",
     "separateMinorPatch": true,


### PR DESCRIPTION
### やったこと
- スケジューリングは npm に限らないので `schedule` をトップレベルに移動
- `schedule` 設定に `after` 句を追加して、月曜8時〜10時の間に動くように変更
- `packageNames` は `matchPackageNames` にリネームされているので、そのように変更
  - https://docs.renovatebot.com/configuration-options/#matchpackagenames