### PR TITLE
chore: renovate が動かない場合があるため、schedule を修正

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     ":label(renovate)",
     ":semanticCommitScopeDisabled"
   ],
-  "schedule": "after 8am before 10am on Monday",
+  "schedule": "before 10am on Monday",
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",


### PR DESCRIPTION
## 背景

プロダクト側で `renovate-config` を使っている場合、たまに renovate からの PR が発行されない週があった。

## やりたいこと

ライブラリの更新は溜め込みたくないため、毎週確実に renovate が実行されるようにしたい。

## 調べたこと

renovate の実行ログを見ていたところ、renovate のジョブ自体は schedule に関わらず、約3時間おきに実行されているようで、
https://app.renovatebot.com/dashboard#github/kufu
![スクリーンショット 2022-08-29 10 48 44](https://user-images.githubusercontent.com/32166731/187107496-b4711b04-d2a4-4e84-9ab9-8d137bfd0a30.png)

各ジョブ内で、実行時の `timestamp` が `renovate.config` の `schedule` の設定に一致していれば PR を作成するような挙動になっているようだった。

その上で、本日分の従業員サーベイにおける renovate の例を上げると

- 7時台に renovate が実行されるが、schedule の範囲外なのでスキップ
- 10時台後半に renovate が実行されるが、schedule の範囲外なのでスキップ

という動きになっており、どちらも `schedule` の設定の `after 8am before 10am on Monday` に一致していなかったため、本日分の renovate からの PR が作成されていなかった 

### やったこと

上記問題を解決するため、`schedule` の設定を `after 8am before 10am on Monday` から `before 10am on Monday` に変更し、確実に renovate が実行されるようにした。

