### PR TITLE
rimraf が v4 にあがらないようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
         ]
       },
       {
-        "packageNames": ["rimraf"],
+        "matchPackageNames": ["rimraf"],
         "allowedVersions": "<4.0.0"
       }
     ]

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,10 @@
         "matchPackagePatterns": [
           "^reg-"
         ]
+      },
+      {
+        "packageNames": ["rimraf"],
+        "allowedVersions": "<4.0.0"
       }
     ]
   }


### PR DESCRIPTION
rimraf の v4 から glob のサポートがなくなりました。

結果として、`rimraf './.next'` という形式だとこれまでと変わらず削除できますが、`rimraf './.next/**/*.map'` という形式だと削除が行われなくなります。
起こりうる問題として、webpack が吐いたソースマップの削除が行われず、本番環境にソースマップが残ってしまう可能性があります。

なので代替策が見つかるまでは v3 で止めておきます。