### PR TITLE
rimraf のアップデートが行われるようにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -47,10 +47,6 @@
         "matchPackagePatterns": [
           "^reg-"
         ]
-      },
-      {
-        "matchPackageNames": ["rimraf"],
-        "allowedVersions": "<4.0.0"
       }
     ]
   }


### PR DESCRIPTION
以前、rimraf が v4 に上がるタイミングで glob のサポートがなくなってしまったため、v4 に上がらないようにしていました。
参考: https://github.com/kufu/renovate-config/pull/21

そして v4.2.0 から glob のサポートが復活したので再びアップデートがされるように、設定を削除しました。

なお、glob サポートを有効にするには `--glob` オプションを付けて実行する必要があるため、プロダクト側での対応が必要になります。
これは別途社内向けに共有しようと思います。