### PR TITLE
chore: 平日のみにrenovateが実行されるように変更

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,7 @@
     ":label(renovate)",
     ":semanticCommitScopeDisabled"
   ],
-  "schedule": "after 8am and before 5pm",
+  "schedule": "after 8am and before 5pm every weekday",
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",


### PR DESCRIPTION
Proposal : 休日にrenovateの通知が来て「ビクぅっ！」となるのを防ぎたい気持ちでPRを出します。
真面目な話だと、automergeが設定されてしまっていて、ライブラリがマージされた影響で障害が発生した時に、すぐ対応ができなくなるリスクもあるので、その辺りもリスクヘッジできるかと思います。(本番影響があるものにautomerge設定することはあまりないとは思いますが、予期せず...)

フロントエンドの定例では一応:gogo:もらっております。

マージされたら念の為に frontendメンバには共有しようと思います :bulb:
