### PR TITLE
ESLint は v9 へのバージョンアップの準備ができていないので、当面の間は対象外とする。

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,7 +29,8 @@
       },
       {
         "matchPackageNames": ["eslint"],
-        "enabled": false
+        "enabled": false,
+        "description": "ESLint v9 は各種プラグインが対応してからバージョンアップの対象にする"
       }
     ]
   }

--- a/default.json
+++ b/default.json
@@ -28,15 +28,8 @@
         "automerge": true
       },
       {
-        "groupName": "ESLint and Prettier",
-        "matchPackageNames": [
-          "eslint",
-          "prettier"
-        ],
-        "matchPackagePatterns": [
-          "^eslint-",
-          "^prettier-"
-        ]
+        "matchPackageNames": ["eslint"],
+        "enabled": false
       }
     ]
   }

--- a/default.json
+++ b/default.json
@@ -37,16 +37,6 @@
           "^eslint-",
           "^prettier-"
         ]
-      },
-      {
-        "groupName": "reg-suit",
-        "matchPackageNames": [
-          "reg-suit",
-          "storycap"
-        ],
-        "matchPackagePatterns": [
-          "^reg-"
-        ]
       }
     ]
   }


### PR DESCRIPTION
ESLint は v9 から flat config がデフォルト化しますが、typescript-eslint を始めとする各種プラグインの対応が出揃わないとバージョンアップするメリットがないため、それまでの間は renovate の対象外とします。