### PR TITLE
cimg/node ではメジャーバージョンを自動であげないようにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -31,6 +31,12 @@
         "matchPackageNames": ["eslint"],
         "enabled": false,
         "description": "ESLint v9 は各種プラグインが対応してからバージョンアップの対象にする"
+      },
+      {
+        "matchPackageNames": ["cimg/node"],
+        "matchUpdateTypes": ["major"],
+        "enabled": false,
+        "description": "cimg/node は CI 上で Node のバージョンを固定した上でテストをしたいパターンがあるので、メジャーバージョンの更新はしない"
       }
     ]
   }


### PR DESCRIPTION
## 概要

renovate が以下のような PR を投げることがある。
[chore: update cimg/node docker tag to v22 by renovate[bot] · Pull Request #270 · kufu/stylelint-config-smarthr](https://github.com/kufu/stylelint-config-smarthr/pull/270)

CircleCI で Node の複数バージョンを指定してテストを動かしている(今回の場合は v18 と v20)が、そのどちらも Node のバージョンを v22 にあげてしまっているパターン。
全く同じ環境で同じコマンドを実行するジョブが2つ存在することになってしまいめっちゃ無駄。

これちゃんと PR 見ないと気づかずマージしちゃいがちなので、この PR 自体が発生しないようにしたい。

## やったこと

`cimg/node` の major を `enabled: false` にした
