### PR TITLE
chore: prevent updating ua-parser-js to v2

### DIFF
--- a/default.json
+++ b/default.json
@@ -37,6 +37,10 @@
         "matchUpdateTypes": ["major"],
         "enabled": false,
         "description": "cimg/node は CI 上で Node のバージョンを固定した上でテストをしたいパターンがあるので、メジャーバージョンの更新はしない"
+      },
+      {
+        "packageNames": ["ua-parser-js"],
+        "allowedVersions": "<2.0.0"
       }
     ]
   }


### PR DESCRIPTION
ua-parser-jsはv2からライセンスがAGPLv3となったため、自動で上がらないように一旦止めておきます

https://github.com/faisalman/ua-parser-js?tab=readme-ov-file#license-options

参考PR：#9