### PR TITLE
renovateによりconfigMigrationを有効にする

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,7 +5,8 @@
     "packages:stylelint",
     ":widenPeerDependencies",
     ":label(renovate)",
-    ":semanticCommitScopeDisabled"
+    ":semanticCommitScopeDisabled",
+    ":configMigration"
   ],
   "schedule": "after 8am and before 5pm every weekday",
   "npm": {


### PR DESCRIPTION
## 概要
renovateでは、日々様々な改良が重ねられており、その過程で設定ファイルの更新が必要になる場合があります。
https://docs.renovatebot.com/config-migration/

このPRでは、renovateがconfigのmigrationをするPull Requestを作成してくれる設定を追加します。

## 変更内容
* `:configMigration`のpresetをextendした
  * https://docs.renovatebot.com/presets-default/#configmigration
  * `npx --yes --package renovate -- renovate-config-validator default.json` で、設定を確認済み