### PR TITLE
ESLint v9 へのアップデートは可能な状態になっているので enable: false の設定を削除

### DIFF
--- a/default.json
+++ b/default.json
@@ -29,11 +29,6 @@
         "automerge": true
       },
       {
-        "matchPackageNames": ["eslint"],
-        "enabled": false,
-        "description": "ESLint v9 は各種プラグインが対応してからバージョンアップの対象にする"
-      },
-      {
         "matchPackageNames": ["cimg/node"],
         "matchUpdateTypes": ["major"],
         "enabled": false,


### PR DESCRIPTION
タイトルのままです！