### PR TITLE
CIの実行回数を抑制する

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,6 +8,7 @@
     ":semanticCommitScopeDisabled",
     ":configMigration"
   ],
+  "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
   "npm": {
     "extends": [


### PR DESCRIPTION
rebasewhenはPRのrebase戦略を定義する。
長い間放置されているPRが永遠とrebaseをしてCIクレジットを消費することを避けたいので、デフォルトで手動実行のみとする。