### PR TITLE
npm:unpublishSafe が動作しない問題を解消

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,14 +6,14 @@
     ":widenPeerDependencies",
     ":label(renovate)",
     ":semanticCommitScopeDisabled",
-    ":configMigration"
+    ":configMigration",
+    "npm:unpublishSafe"
   ],
   "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",
-      "npm:unpublishSafe",
       "helpers:disableTypesNodeMajor"
     ],
     "rangeStrategy": "bump",


### PR DESCRIPTION
`npm:unpublishSafe` が動作していません。

現在の設定だと "npm" 配下で extends されているのですが、`npm:unpublishSafe` の定義側でも "npm" のセクションが定義されており、ネストされてしまっているようです。

https://github.com/renovatebot/renovate/blob/2e5288bc9a62b517e5ade40e922e5ba55afeb7a4/lib/config/presets/internal/npm.ts

`npm:unpublishSafe` の配置場所を最も外側の extends 側に移動することで、この問題を解消します。