### PR TITLE
npm packageのminimumReleaseAgeを7 daysにする

### DIFF
--- a/default.json
+++ b/default.json
@@ -21,6 +21,12 @@
     "separateMinorPatch": true,
     "packageRules": [
       {
+        "description": "minimumReleaseAgeを社内規定に沿って7 daysにセットする",
+        "internalChecksFilter": "strict",
+        "matchDatasources": ["npm"],
+        "minimumReleaseAge": "7 days"
+      },
+      {
         "matchDepTypes": [
           "devDependencies"
         ],


### PR DESCRIPTION
## 概要
kufuのrenovateの設定では、以前からpresetの `npm:unpublishSafe` を有効化しています。

ただ、昨今のサプライチェーン攻撃の激化に対して、より安全な設定に倒したいため、 `minimumReleaseAge` を 7daysに伸ばします。

## 変更内容
* [presetのルール](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm)を元に、 `packageRules` を定義した