### PR TITLE
configのmigration対応

### DIFF
--- a/default.json
+++ b/default.json
@@ -7,7 +7,7 @@
     ":label(renovate)",
     ":semanticCommitScopeDisabled",
     ":configMigration",
-    "npm:unpublishSafe"
+    "security:minimumReleaseAgeNpm"
   ],
   "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
@@ -36,7 +36,7 @@
         "description": "cimg/node は CI 上で Node のバージョンを固定した上でテストをしたいパターンがあるので、メジャーバージョンの更新はしない"
       },
       {
-        "packageNames": ["ua-parser-js"],
+        "matchPackageNames": ["ua-parser-js"],
         "allowedVersions": "<2.0.0"
       }
     ]


### PR DESCRIPTION
## 概要
いくつかmigrationが必要な設定があったので対応を行います

## 変更内容
* configのmigrationを実施した

## 確認方法
* ` npx --yes --package renovate -- renovate-config-validator default.json` でwarningが表示されなければOK