### PR TITLE
GHAのSHA固定に伴う対応

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,19 @@
   ],
   "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
+  "github-actions": {
+    "extends": [
+      "helpers:pinGitHubActionDigests",
+      ":noUnscheduledUpdates"
+    ],
+    "packageRules": [
+      {
+        "description": "GitHub Actionsのactionに7日間のクールダウンを設ける",
+        "matchManagers": ["github-actions"],
+        "minimumReleaseAge": "7 days"
+      }
+    ]
+  },
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",

--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -1,0 +1,4 @@
+{
+  "onboarding": false,
+  "requireConfig": "required"
+}


### PR DESCRIPTION
### 関連リンク
- 方針決め
  - https://www.notion.so/GHA-SHA-36837b6398eb803f8fa5f892bf418069?source=copy_link#36b37b6398eb8062bd26c495a63b1114
  - 調査して対応は少し変えてます。

## やったこと
### 1. org-inherited-config.json の追加

Renovate の権限をAllRepositoryに変更した時に各リポジトリへオンボーディングPRが自動作成されるのを防ぐため、`org-inherited-config.json` を追加しました。

- `"onboarding": false` — オンボーディングPRを作成しない
- `"requireConfig": "required"` — 各リポジトリに renovate.json がない場合は Renovate を実行しない

参考: https://docs.renovatebot.com/config-overview/#changing-default-behavior

### 2. GitHub Actions 向けの設定追加

`default.json` に GitHub Actions の action 更新に関する設定を追加しました。

- **SHA digest での固定** (`helpers:pinGitHubActionDigests`)
  - action のバージョン指定をタグではなく SHA で固定し、サプライチェーン攻撃のリスクを軽減する
- **7日間のクールダウン** (`minimumReleaseAge: "7 days"`)
  - リリースから7日間は更新PRを作成せず、悪意のあるパッケージが検出・削除される猶予期間を設ける

各リポジトリで以下のように設定すると適用されます：

```json
{
  "extends": ["github>kufu/renovate-config"],
  "enabledManagers": ["github-actions"]
}
```

