### PR TITLE
inherited-configを削除

### DIFF
--- a/org-inherited-config.json
+++ b/org-inherited-config.json
@@ -1,4 +1,0 @@
-{
-  "onboarding": false,
-  "requireConfig": "required"
-}


### PR DESCRIPTION
この設定だと、オンボーディングがない状態でrenovateが勝手に動いてしまうため削除する