### PR TITLE
renovateを対象外とするため、ghaの設定を戻す

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,19 +11,6 @@
   ],
   "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
-  "github-actions": {
-    "extends": [
-      "helpers:pinGitHubActionDigests",
-      ":noUnscheduledUpdates"
-    ],
-    "packageRules": [
-      {
-        "description": "GitHub Actionsのactionに7日間のクールダウンを設ける",
-        "matchManagers": ["github-actions"],
-        "minimumReleaseAge": "7 days"
-      }
-    ]
-  },
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",


### PR DESCRIPTION
renovateをAllRepositoryに変更するのを一旦取りやめとしたため、設定を戻す
- 元の対応PR
  - https://github.com/kufu/renovate-config/pull/38