### PR TITLE
semanticCommitを強制する

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,7 @@
     "packages:stylelint",
     ":widenPeerDependencies",
     ":label(renovate)",
+    ":semanticCommits",
     ":semanticCommitScopeDisabled",
     ":configMigration",
     "security:minimumReleaseAgeNpm"


### PR DESCRIPTION
## 概要
現状は、renovateが自動でsemantic commitを使用するか判別している。
都度PRタイトルが変わるのは煩わしさもあるので、semantic commitを強制する