### PR TITLE
group:stylelintをextendする

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "extends": [
     ":timezone(Asia/Tokyo)",
     "group:monorepos",
-    "packages:stylelint",
+    "group:stylelint",
     ":widenPeerDependencies",
     ":label(renovate)",
     ":semanticCommitScopeDisabled",


### PR DESCRIPTION
## 概要
現在、 `packages:stylelint` がextendされていますが、このpresetは単に`matchPackageNames` を定義しているだけなので、単体ではあまり意味がありません。
https://docs.renovatebot.com/presets-packages/#packagesstylelint

https://github.com/renovatebot/renovate/pull/43351 でstylelintをgroup化する `group:stylelint` presetが追加されたので、こちらをextendするようにします。