### PR TITLE
dependabotでGitHub Actionsを定期更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+version: 2
+
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: monthly
+    time: "09:00"
+    timezone: Asia/Tokyo
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
## 概要
GitHub Actionsを定期更新できるようにdependabotを設定します。