### PR TITLE
[Proposal] CIのnpx latest実行を廃止し、digest固定した公式コンテナに移行する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,9 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: lts/*
       - name: Validate renovate config
-        run: RENOVATE_CONFIG_FILE=default.json npx --package renovate -c 'renovate-config-validator'
+        run: |
+          docker run --rm --network none \
+            -v "$GITHUB_WORKSPACE:/work:ro" -w /work \
+            ghcr.io/renovatebot/renovate:43.263.7@sha256:961d3785fb5a27ecffe3f82b3a1764d320f42cea71311637722bc23c866ac4e3 \
+            renovate-config-validator default.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,11 +5,17 @@ on:
   push:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: lts/*


### PR DESCRIPTION
## 背景

2026-08-05、npm で Shai-Hulud 系の自己複製型ワームによる大規模侵害が発生しました。

- 起点は `keyv`(月604M DL)、`flat-cache`、`file-entry-cache` など11パッケージ。メンテナの GitHub アカウントが侵害され、main への直接 push → 即リリースで配信
- 最終的に444パッケージ / 1,381バージョンに自己増殖
- ペイロードは `preinstall` フックから起動し、**GitHub Actions ランナー上でプロセスメモリを直接読んでシークレットストア全体と OIDC トークンをダンプ**します

参考: https://www.aikido.dev/blog/keyv-and-friends-compromised-in-npm-supply-chain-attack

## 現状の問題

このリポジトリの CI は `npx` をバージョン無指定で実行していました。

```yaml
run: RENOVATE_CONFIG_FILE=default.json npx --package renovate -c 'renovate-config-validator'
```

1. **毎回 `renovate@latest` を解決**。lockfile なし、integrity hash なし、lifecycle script 有効
2. **今回汚染された `keyv` が読み込まれる経路上にいます**(実測で確認)

   ```
   renovate → got@14.6.6 → cacheable-request → keyv@^5.6.0
                                                     ↑ レンジ指定
   ```

   renovate 本体の直接依存117個はすべて exact pin されていますが、**推移依存はレンジ解決されるため毎回フレッシュに取得されます**
3. **`permissions:` が未設定**のため、GITHUB_TOKEN の権限がリポジトリ/organization のデフォルト設定に依存していました
4. Actions は full SHA pin 済み(#41)で良好。**npm 側だけが未対策という非対称**な状態でした

### リスク評価

**緩和要因**: secrets 参照なし / `pull_request`(`pull_request_target` ではない)なので fork PR は read-only + secrets なし / 実行頻度は年数十回程度 / 最終コミットが 2026-07-27 なので今回の侵害ウィンドウで CI が走った可能性は低い。

**残存リスク**: 最大の脅威は直接被害ではなく、**このリポジトリが全社の依存元である**ことです。各プロダクトは `"extends": ["github>kufu/renovate-config"]` とデフォルトブランチ参照で使っているため、master の `default.json` を書き換えられると `minimumReleaseAge: "7 days"` / `internalChecksFilter: "strict"` が全社で一斉に無効化され、**後続のすべての npm 攻撃の被害が増幅されます**。

> 発生確率: 低 / 影響度: 高 / 修正コスト: 小

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| renovate の取得 | `npx --package renovate`(= 毎回 latest) | `ghcr.io/renovatebot/renovate:43.263.7@sha256:961d37…` を digest 固定 |
| GITHUB_TOKEN | `permissions:` なし | `contents: read` |
| checkout の認証情報 | `.git/config` に残留 | `persist-credentials: false` |
| ネットワーク | 制限なし | `--network none` で遮断 |
| タイムアウト | なし | `timeout-minutes: 10` |
| `actions/setup-node` | 必要 | 不要になったので削除 |

digest 固定は**イメージのバイト列そのものを確定させる**ため、「install script が走るか」「import 時に実行されるか」という議論自体が消えます。npm registry への接続が CI から消え、供給網の接点が digest 固定の単一アーティファクト1個に縮みます。

**追加ファイルはありません。`dependabot.yml` / `default.json` も変更していません。**

## 検討したが採用しなかった案

| 案 | 不採用の理由 |
|---|---|
| `npx --package renovate@x.y.z` | トップレベルを固定しても**推移依存はレンジ解決される**。今回の `keyv` はまさにその層なので防げない |
| `package.json` + lockfile | 全推移依存を integrity 固定できるが、**バリデーション1回のために package 管理一式を持ち込むのは過剰**と判断 |
| `--ignore-scripts` 単独 | 今回のペイロードは `preinstall` 起動なので防げるが、それは実装の都合。モジュールのトップレベルに置かれれば import 時に実行され無力 |
| suzuki-shunsuke/github-action-renovate-config-validator | `runs.using: composite` で内部が `actions/setup-node` + `actions/cache` + `npx --yes --package "renovate@${VALIDATOR_VERSION:-latest}"`。**今回直す対象をそのまま内包**している |
| tj-actions/renovate-config-validator | `image: docker://ghcr.io/tj-actions/renovate-config-validator:latest` で**タグ固定なし**。加えて tj-actions は2025年3月に `changed-files` で大規模な供給網侵害を受けた組織 |
| harden-runner | digest 固定 + `--network none` の後では守る対象がほぼ残らず、3rd party action が1つ増える分だけ不利 |

## 検証結果

ローカルで終了コードを実測しました。

| ケース | `--network none` | ネットワーク有 |
|---|---|---|
| `default.json`(正常) | **0** | 0 |
| 不正なオプション名 | **1** | 1 |
| 存在しない内部 preset | **0** | 0 |
| 存在しないリモート preset | **0** | 0 |
| JSON 構文エラー | **1** | 1 |

- **`--network none` はネットワーク有と完全に等価**でした
- CI と同一のコマンド(`GITHUB_WORKSPACE` をマウント)をローカル実行し `exit=0` を確認済み

### ⚠️ 検証中に判明したこと: validator は preset の実在を検証しない

上表の通り、`group:thisPresetDoesNotExist` も `github>存在しない組織/nope` も、ネットワーク有無・`--strict` の有無に関わらず通ります。検出できるのは**不正なオプション名と JSON 構文エラーのみ**です。

つまり **preset 名の typo は CI で防げず、そのまま全社に配布されます**。本 PR のスコープ外ですが、既存の穴として別途起票すべきと考えています。

## トレードオフ: イメージの更新が手動になります

Dependabot はワークフロー内のコンテナ参照を更新しません。

- GitHub Actions ecosystem は `owner/repo@ref` 形式のみ対応で、`docker://` 構文および ghcr / Docker Hub の URL は非対応([GitHub Docs](https://docs.github.com/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories))
- ワークフロー内の `container:` 更新要望は [dependabot-core#5819](https://github.com/dependabot/dependabot-core/issues/5819) が2022年9月から open

実害は小さいと考えています。バージョンが陳腐化して困るのは「新しい設定オプションが誤って invalid 判定される」ケースで、**CI 失敗として可視化される**だけであり、セキュリティが劣化する方向ではありません。四半期に一度手で上げれば十分です。

更新手順:

```bash
docker pull ghcr.io/renovatebot/renovate:<新バージョン>
docker images --digests ghcr.io/renovatebot/renovate:<新バージョン> --format '{{.Digest}}'
# 得られた digest で test.yml の参照を差し替える
```

## レビュー時に確認したい点

- [ ] CI が green になること
- [ ] **コンテナは UID 12021 で動くため、マウントした `default.json` を読めるか**(ローカルでは問題なし。ランナー上で要確認。落ちる場合は `--user "$(id -u)"` の追加で対応可能)
- [ ] Actions ログ冒頭の "GITHUB_TOKEN Permissions" が `Contents: read` のみになっていること
- [ ] イメージ pull による実行時間の増分が許容範囲(+30〜60秒程度)であること
- [ ] 「更新が手動になる」トレードオフを受け入れてよいか

## あわせて確認したい GitHub 設定(本 PR の対象外)

1. 2026-08-05 以降の Actions 実行履歴の有無(最終コミットが 07-27 なので恐らく無し = 今回は踏んでいない、と確認したい)
2. Settings → Actions → General → Workflow permissions が "Read repository contents permission" になっているか
3. master の branch protection / ruleset(branch protection は GITHUB_TOKEN にも適用されるため、改ざん防止の実効的な最後の砦)

## 別途起票したい論点

- **preset 名 typo が検出されない**(本 PR の検証で判明)
- **`default.json` の devDependencies patch automerge** — 全リポジトリの挙動が変わるため本 PR には含めていません。`minimumReleaseAge: 7 days` + `internalChecksFilter: strict` により automerge も7日経過後にしか起きず今回型の攻撃にはかなり有効な一方、7日を生き延びた汚染パッケージは全社に無人でマージされます
- **consumers 側の preset 参照をタグ固定にする** — 「master 改ざんが即全社波及する」構造的問題の本丸。org 横断の中期課題

🤖 Generated with [Claude Code](https://claude.com/claude-code)
