### PR TITLE
Add rubygems  to minimumReleaseAge rule

### DIFF
--- a/default.json
+++ b/default.json
@@ -24,7 +24,7 @@
       {
         "description": "minimumReleaseAgeを社内規定に沿って7 daysにセットする",
         "internalChecksFilter": "strict",
-        "matchDatasources": ["npm"],
+        "matchDatasources": ["npm", "rubygems"],
         "minimumReleaseAge": "7 days"
       },
       {

--- a/default.json
+++ b/default.json
@@ -12,6 +12,14 @@
   ],
   "rebaseWhen": "never",
   "schedule": "after 8am and before 5pm every weekday",
+  "packageRules": [
+    {
+      "description": "minimumReleaseAgeを社内規定に沿って7 daysにセットする",
+      "internalChecksFilter": "strict",
+      "matchDatasources": ["npm", "rubygems", "docker"],
+      "minimumReleaseAge": "7 days"
+    }
+  ],
   "npm": {
     "extends": [
       ":noUnscheduledUpdates",
@@ -21,12 +29,6 @@
     "semanticCommitType": "chore",
     "separateMinorPatch": true,
     "packageRules": [
-      {
-        "description": "minimumReleaseAgeを社内規定に沿って7 daysにセットする",
-        "internalChecksFilter": "strict",
-        "matchDatasources": ["npm", "rubygems"],
-        "minimumReleaseAge": "7 days"
-      },
       {
         "matchDepTypes": [
           "devDependencies"

--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
     {
       "description": "minimumReleaseAgeを社内規定に沿って7 daysにセットする",
       "internalChecksFilter": "strict",
-      "matchDatasources": ["npm", "rubygems", "docker"],
+      "matchUpdateTypes": ["major", "minor", "patch", "digest", "pinDigest"],
       "minimumReleaseAge": "7 days"
     }
   ],


### PR DESCRIPTION
RubyGemsもRenovateで管理しているプロジェクトでクールダウンが効いていなかったので、追加しました

[Minimum Release Age - Renovate Docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/#which-registries-support-release-timestamps)